### PR TITLE
Add `tx_power` to region_au915.toml

### DIFF
--- a/configuration/region_au915.toml
+++ b/configuration/region_au915.toml
@@ -75,6 +75,8 @@
     927100000,
   ]
 
+  tx_power = [12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27]
+
   [[mappings.data_rates]]
     modulation = "LORA"
     spreading_factor = 12


### PR DESCRIPTION
Fixes the error message `Handle command error: No TX Power equal or lower than:` when sending downlink messages