### PR TITLE
Merge branch 'codex/add-4-byte-timestamp-to-relayed-uplink'

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,6 +38,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstyle"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -162,6 +177,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "chirpstack_api",
+ "chrono",
  "clap",
  "cmac",
  "futures",
@@ -194,6 +210,18 @@ dependencies = [
  "prost-types",
  "rand 0.9.2",
  "tonic-build",
+]
+
+[[package]]
+name = "chrono"
+version = "0.4.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "num-traits",
+ "windows-link",
 ]
 
 [[package]]
@@ -264,6 +292,12 @@ dependencies = [
  "lazy_static",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -692,6 +726,30 @@ checksum = "57a3db5ea5923d99402c94e9feb261dc5ee9b4efa158b0315f788cf549cc200c"
 dependencies = [
  "humantime",
  "serde",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1824,10 +1882,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@
   zmq = "0.10"
   cmac = "0.7"
   aes = "0.8"
+  chrono = { version = "0.4", default-features = false, features = ["clock"] }
 
 [dev-dependencies]
   zeromq = "0.4"

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 
 use crate::config;
 use chirpstack_api::gw;
+use chrono::{Timelike, Utc};
 
 pub fn frequency_to_chan(freq: u32) -> Result<u8> {
     let conf = config::get();
@@ -177,6 +178,12 @@ pub fn tx_ack_to_err(tx_ack: &gw::DownlinkTxAck) -> Result<()> {
     } else {
         Ok(())
     }
+}
+
+// Returns the milliseconds since midnight (UTC).
+pub fn ms_since_midnight() -> u32 {
+    let now = Utc::now();
+    now.num_seconds_from_midnight() * 1000 + u32::from(now.timestamp_subsec_millis())
 }
 
 pub fn format_uplink(pl: &gw::UplinkFrame) -> Result<String> {

--- a/tests/border_gateway_uplink_lora.rs
+++ b/tests/border_gateway_uplink_lora.rs
@@ -31,6 +31,7 @@ async fn test_border_gateway_uplink_lora() {
         rx_info: Some(gw::UplinkRxInfo {
             gateway_id: "0101010101010101".to_string(),
             crc_status: gw::CrcStatus::CrcOk.into(),
+            uplink_id: 123456,
             ..Default::default()
         }),
         ..Default::default()
@@ -65,6 +66,13 @@ async fn test_border_gateway_uplink_lora() {
         }
     };
 
-    // Validate they are equal.
-    assert_eq!(up, up_received);
+    // Validate forwarded uplink including metadata.
+    let mut up_expected = up.clone();
+    if let Some(rx_info) = &mut up_expected.rx_info {
+        rx_info
+            .metadata
+            .insert("uplink_id".to_string(), rx_info.uplink_id.to_string());
+    }
+
+    assert_eq!(up_expected, up_received);
 }

--- a/tests/border_gateway_uplink_mesh.rs
+++ b/tests/border_gateway_uplink_mesh.rs
@@ -32,6 +32,7 @@ async fn test_border_gateway_uplink_mesh() {
                 snr: 6,
                 channel: 2,
             },
+            timestamp: 0,
             relay_id: [1, 2, 3, 4],
             phy_payload: vec![9, 8, 7, 6],
         }),
@@ -54,6 +55,7 @@ async fn test_border_gateway_uplink_mesh() {
         }),
         rx_info: Some(gw::UplinkRxInfo {
             crc_status: gw::CrcStatus::CrcOk.into(),
+            uplink_id: 123456,
             ..Default::default()
         }),
         ..Default::default()
@@ -110,22 +112,14 @@ async fn test_border_gateway_uplink_mesh() {
 
     // Validate RxInfo (GatewayID, context, RSSI & SNR)
     let rx_info = up.rx_info.as_ref().unwrap();
-    assert_eq!(
-        &gw::UplinkRxInfo {
-            gateway_id: "0101010101010101".to_string(),
-            rssi: -60,
-            snr: 6.0,
-            context: vec![1, 2, 3, 1, 2, 3, 4, 0, 123],
-            crc_status: gw::CrcStatus::CrcOk.into(),
-            metadata: [
-                ("relay_id".to_string(), "01020304".to_string()),
-                ("hop_count".to_string(), "1".to_string()),
-            ]
-            .iter()
-            .cloned()
-            .collect(),
-            ..Default::default()
-        },
-        rx_info
-    );
+    assert_eq!("0101010101010101", rx_info.gateway_id);
+    assert_eq!(-60, rx_info.rssi);
+    assert_eq!(6.0, rx_info.snr);
+    assert_eq!(vec![1, 2, 3, 1, 2, 3, 4, 0, 123], rx_info.context);
+    assert_eq!(gw::CrcStatus::CrcOk as i32, rx_info.crc_status);
+    assert_eq!("01020304", rx_info.metadata.get("relay_id").unwrap());
+    assert_eq!("1", rx_info.metadata.get("hop_count").unwrap());
+    assert_eq!("123", rx_info.metadata.get("uplink_id").unwrap());
+    assert_eq!(123, rx_info.uplink_id);
+    assert!(rx_info.metadata.contains_key("mesh_delay_ms"));
 }

--- a/tests/relay_gateway_uplink_lora.rs
+++ b/tests/relay_gateway_uplink_lora.rs
@@ -78,6 +78,11 @@ async fn test_relay_gateway_uplink_lora() {
 
     let down_item = down.items.first().unwrap();
     let mesh_packet = packets::MeshPacket::from_slice(&down_item.phy_payload).unwrap();
+    let ts = if let packets::Payload::Uplink(pl) = &mesh_packet.payload {
+        pl.timestamp
+    } else {
+        0
+    };
 
     assert_eq!(
         {
@@ -94,6 +99,7 @@ async fn test_relay_gateway_uplink_lora() {
                         snr: 12,
                         channel: 1,
                     },
+                    timestamp: ts,
                     relay_id: [2, 2, 2, 2],
                     phy_payload: vec![1, 2, 3, 4, 5, 6, 7, 8],
                 }),


### PR DESCRIPTION
(cherry picked from commit 1d5505872dae5a512e51c05480f656f9fd08751a)基于 tag v4.1.0 迁移，仅改动 uplink 解包/日志元数据注入路径，不变更心跳/事件；附上测试方法。